### PR TITLE
Added suppresion for cve-2018-1258

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -33,10 +33,10 @@
 
   <suppress>
    <notes><![CDATA[
-   file name: spring-security-crypto-5.1.5.RELEASE.jar
+   file name: spring-security-crypto-5.2.1.RELEASE.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
-   <cve>CVE-2020-5398</cve>
-  </suppress>
+   <cve>CVE-2018-1258</cve>
+</suppress>
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -33,7 +33,7 @@
 
   <suppress>
    <notes><![CDATA[
-   file name: spring-security-crypto-5.2.1.RELEASE.jar
+   this is a false positive. The vulnerability was resolved when upgrading spring boot version to 2.2.4
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
    <cve>CVE-2018-1258</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -37,6 +37,6 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
    <cve>CVE-2018-1258</cve>
-</suppress>
+  </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#697](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/697)

### Change description ###

Removed unnecessary suppression for CVE-2020-539. This was resolved via spring boot upgrade.

Added suppresion for cve-2018-1258 as this is a false positive.  For further details:

"Updating to Spring Security 5.0.5.RELEASE+ or Spring Boot 2.0.2.RELEASE+ brings in Spring Framework 5.0.6.RELEASE+ transitively" (https://pivotal.io/security/cve-2018-1258)

As we are running version 2.2.4 of spring boot this is no longer applicable. There is an open issue for this false positive here:

https://github.com/jeremylong/DependencyCheck/issues/1827

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
