### PR TITLE
DTSPO-8276 - Edit and move CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 
-CODEOWNERS @hmcts/platform-operations
+* @hmcts/platform-operations


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-8276


### Change description ###
- Move CODEOWNERS to .github to reduce the number of files in the root of the repo
- Edit CODEOWNERS - replaced 'CODEOWNERS' with '*' to cover all files in the repo not just CODEOWNERS


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```