### PR TITLE
Remove useless log spam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.11'
 
-  implementation group: 'com.github.hmcts', name: 'java-logging', version: '5.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 
   compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion


### PR DESCRIPTION
prod logs are full of:

```
2022-09-22T10:22:55.215 INFO  [http-nio-4550-exec-2] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 0ms
2022-09-22T10:23:06.556 INFO  [http-nio-4550-exec-3] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /recipes processed in 10ms
2022-09-22T10:23:10.216 INFO  [http-nio-4550-exec-5] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 0ms
2022-09-22T10:23:10.216 INFO  [http-nio-4550-exec-4] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 0ms
2022-09-22T10:23:25.215 INFO  [http-nio-4550-exec-6] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
2022-09-22T10:23:25.215 INFO  [http-nio-4550-exec-7] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:23:40.215 INFO  [http-nio-4550-exec-8] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:23:40.215 INFO  [http-nio-4550-exec-9] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
2022-09-22T10:23:55.215 INFO  [http-nio-4550-exec-10] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
2022-09-22T10:23:55.215 INFO  [http-nio-4550-exec-1] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:24:10.215 INFO  [http-nio-4550-exec-2] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:24:10.215 INFO  [http-nio-4550-exec-3] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
2022-09-22T10:24:25.215 INFO  [http-nio-4550-exec-5] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:24:25.215 INFO  [http-nio-4550-exec-4] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
2022-09-22T10:24:40.215 INFO  [http-nio-4550-exec-6] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 0ms
2022-09-22T10:24:40.216 INFO  [http-nio-4550-exec-7] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:24:55.216 INFO  [http-nio-4550-exec-9] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:24:55.216 INFO  [http-nio-4550-exec-8] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 0ms
2022-09-22T10:25:10.214 INFO  [http-nio-4550-exec-10] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 0ms
2022-09-22T10:25:10.215 INFO  [http-nio-4550-exec-1] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 0ms
2022-09-22T10:25:25.215 INFO  [http-nio-4550-exec-3] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/readiness processed in 1ms
2022-09-22T10:25:25.215 INFO  [http-nio-4550-exec-2] u.g.h.r.logging.filters.RequestStatusLoggingFilter Request GET /health/liveness processed in 1ms
```