### PR TITLE
expiresAfter() tag testing - Key Vault

### DIFF
--- a/infrastructure/expAfter-testing.tf
+++ b/infrastructure/expAfter-testing.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "expAfter_testing_rg" {
 
 resource "azurerm_key_vault" "expAfter_testing_kv" {
   name                = "expAfter-testing-${var.env}"
-  location            = azurerm_resource_group.expAfter_testing.location
+  location            = azurerm_resource_group.expAfter_testing_rg.location
   resource_group_name = azurerm_key_vault.expAfter_testing_rg.name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id

--- a/infrastructure/expAfter-testing.tf
+++ b/infrastructure/expAfter-testing.tf
@@ -1,0 +1,9 @@
+resource "azurerm_resource_group" "expAfter_testing_rg" {
+  name     = "expAfter-testing-${var.env}"
+  location = "UK South"
+}
+
+data "azurerm_key_vault" "expAfter_testing_kv" {
+  name                = "expAfter-testing-${var.env}"
+  resource_group_name = azurerm_key_vault.expAfter_testing_rg.name
+}

--- a/infrastructure/expAfter-testing.tf
+++ b/infrastructure/expAfter-testing.tf
@@ -3,7 +3,31 @@ resource "azurerm_resource_group" "expAfter_testing_rg" {
   location = "UK South"
 }
 
-data "azurerm_key_vault" "expAfter_testing_kv" {
+resource "azurerm_key_vault" "expAfter_testing_kv" {
   name                = "expAfter-testing-${var.env}"
+  location            = azurerm_resource_group.expAfter_testing.location
   resource_group_name = azurerm_key_vault.expAfter_testing_rg.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Get",
+    ]
+
+    storage_permissions = [
+      "Get",
+    ]
+  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-11797


### Change description ###

add new resource group and key vault for expiresAfter() tagging testing as part of finOps implementations


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
