### PR TITLE
Add rhubarb database

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -86,7 +86,9 @@ module "postgresql_flexible" {
   admin_user_object_id = var.jenkins_AAD_objectId
   pgsql_databases = [
     {
-      name : "plum",
+      name : "plum"
+    },
+    {
       name : "rhubarb"
     }
   ]

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -86,7 +86,8 @@ module "postgresql_flexible" {
   admin_user_object_id = var.jenkins_AAD_objectId
   pgsql_databases = [
     {
-      name : "plum"
+      name : "plum",
+      name : "rhubarb"
     }
   ]
 


### PR DESCRIPTION
Currently facing this error in sbox for crumble-recipes:
```
Caused by: org.flywaydb.core.internal.exception.FlywaySqlException: Unable to obtain connection from database: FATAL: database "rhubarb" does not exist
```

Somehow this db exists in plum-v14-server but doesn't for crumble one, this _should_ add a rhubarb database to `crumble-v14-flexible-sandbox` and maybe a conflicting resource for plum flexi servers



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
