### PR TITLE
fix for github actions: Run Swagger Publisher stage

### DIFF
--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -19,8 +19,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: 'zulu'
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '21'
+          cache: 'gradle'
       - name: Run Swagger Publisher
         run: ./gradlew test --tests uk.gov.hmcts.reform.rhubarb.recipes.SwaggerPublisher
       - name: Commit to repository


### PR DESCRIPTION
Stage currently failing because of org.springframework.boot:spring-boot-gradle-plugin:3.2.0  with JDK11

eg. https://github.com/hmcts/cnp-plum-recipes-service/actions/runs/8420203916/job/23054421520