### PR TITLE
DTSPO-17617 - Add value for flexible server sku

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -98,38 +98,6 @@ module "postgresql_flexible" {
   pgsql_sku     = var.pgsql_sku
 }
 
-# region API (gateway)
-
-module "plum_product" {
-  source = "git@github.com:hmcts/cnp-module-api-mgmt-product?ref=master"
-
-  api_mgmt_name = "core-api-mgmt-${var.env}"
-  api_mgmt_rg   = "core-infra-${var.env}"
-
-  name = "plum-recipes"
-}
-
-module "api" {
-  source         = "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=master"
-  name           = "${var.product}-recipes-api"
-  api_mgmt_rg    = "core-infra-${var.env}"
-  api_mgmt_name  = "core-api-mgmt-${var.env}"
-  display_name   = "${var.product}-recipes"
-  revision       = "1"
-  product_id     = module.plum_product.product_id
-  path           = local.api_base_path
-  service_url    = "http://${var.product}-${local.app}-${var.env}.service.core-compute-${var.env}.internal"
-  swagger_url    = "https://raw.githubusercontent.com/hmcts/reform-api-docs/master/docs/specs/cnp-plum-recipes-service.json"
-  content_format = "openapi+json-link"
-}
-
-module "policy" {
-  source                 = "git@github.com:hmcts/cnp-module-api-mgmt-api-policy?ref=master"
-  api_mgmt_name          = "core-api-mgmt-${var.env}"
-  api_mgmt_rg            = "core-infra-${var.env}"
-  api_name               = module.api.name
-  api_policy_xml_content = local.api_policy
-}
 # endregion
 
 # REDIS CACHE TESTING

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -95,6 +95,7 @@ module "postgresql_flexible" {
   ]
 
   pgsql_version = "16"
+  pgsql_sku     = var.pgsql_sku
 }
 
 # region API (gateway)

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -3,3 +3,4 @@ rdb_backup_enabled                      = false
 family                                  = "C"
 sku_name                                = "Basic"
 rdb_backup_max_snapshot_count           = "1"
+pgsql_sku                               = "Standard_B1ms"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -3,4 +3,4 @@ rdb_backup_enabled                      = false
 family                                  = "C"
 sku_name                                = "Basic"
 rdb_backup_max_snapshot_count           = "1"
-pgsql_sku                               = "Standard_B1ms"
+pgsql_sku                               = "B_Standard_B1ms"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -44,3 +44,7 @@ variable "autoheal" {
 variable "private_dns_subscription_id" {
   default = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 }
+
+variable "pgsql_sku" {
+  default = "GP_Standard_D2s_v3"
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-17617

### Change description

Changing sandbox to use the burstable sku
This is to test whether this will work for plum so we can have sandbox start up automatically every morning.
This will reduce cost and keep pipelines working that rely on plum sandbox being reachable.
Removing api mgmt related resources as the api mgmt instance has been removed.

### Testing done

The website seems to still load after the change in SKU.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
