### PR TITLE
Fix expiresAfter tag

### DIFF
--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -40,6 +40,9 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   ]
 }
 
+// Stops sbox DBs being removed and blocking our builds
+def expiresAfter = "3000-01-01"
+
 withPipeline(type, product, app) {
   // never skip stages when testing the pipeline
   env.NO_SKIP_IMG_BUILD = 'true'


### PR DESCRIPTION
This pipeline builds the crumble DB in sbox, which destroys every 2 weeks and when it does causes issues for our pipelines that are running health checks against plum in sbox. This change will stop it from expiring by updating the `expiresAfter` tag