### PR TITLE
DTSPO-31128: enroll prod db to backup vault as final test

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -98,6 +98,7 @@ module "postgresql_flexible" {
   pgsql_sku     = var.pgsql_sku
 
   service_criticality = var.service_criticality
+  backup_policy_id    = var.backup_policy_id
 }
 
 # endregion

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -5,3 +5,5 @@ family                                  = "C"
 sku_name                                = "Basic"
 rdb_backup_max_snapshot_count           = "1"
 pgsql_sku                               = "GP_Standard_D2s_v3"
+service_criticality                     = 4
+backup_policy_id                        = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/mgmt-infra-prod-rg/providers/Microsoft.DataProtection/backupVaults/cnp-backup-vault/backupPolicies/postgresql-test"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -87,6 +87,12 @@ variable "service_criticality" {
   default     = 1
 }
 
+variable "backup_policy_id" {
+  description = "The resource ID of the backup policy to use for PostgreSQL Flexible Server backup. This should be in the format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{backupVaultName}/backupPolicies/{backupPolicyName}"
+  type        = string
+  default     = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/mgmt-infra-prod-rg/providers/Microsoft.DataProtection/backupVaults/cnp-backup-vault/backupPolicies/postgresql-crit4-5"
+}
+
 variable "asp_sku_size" {
   type        = string
   description = "SKU size for the App Service Plan (e.g. B1, P1v3)."


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31128

### Change description

- enroll plum prod db as final test to final backup-vault
- immutability is OFF, soft-delete is ON
- expect initial backup point to be deleted and not restorable via soft delete after policy expiration
- test policy being used is test, this has 7 day retention

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
