### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.2.0")
+@Library("Infrastructure@2.4.2")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.2")
+@Library("Infrastructure@2.4.3")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
   ]),
 ])
 
-@Library("Infrastructure@2.4.2")
+@Library("Infrastructure@2.4.3")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
   ]),
 ])
 
-@Library("Infrastructure@2.2.0")
+@Library("Infrastructure@2.4.2")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
   ]),
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "java"
 def product = "plum"

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -13,7 +13,7 @@
 
 properties([
   parameters([
-    string(name: 'LIB_VERSION', defaultValue: 'master', description: 'Branch name of pipeline library to use')
+    string(name: 'LIB_VERSION', defaultValue: '2.4.3', description: 'Branch name of pipeline library to use')
   ])
 ])
 


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
